### PR TITLE
change confirm url to ssl

### DIFF
--- a/catalog/controller/payment/liqpay.php
+++ b/catalog/controller/payment/liqpay.php
@@ -91,7 +91,7 @@ class ControllerPaymentLiqpay extends Controller
         $this->data['signature']      = $signature;
         $this->data['data']           = $data;
         $this->data['button_confirm'] = 'Оплатить';
-        $this->data['url_confirm']    = $this->url->link('payment/liqpay/confirm');
+        $this->data['url_confirm']    = $this->url->link('payment/liqpay/confirm', '', 'SSL');
         
         $this->template = $this->config->get('config_template').'/template/payment/liqpay.tpl';
 


### PR DESCRIPTION
It is necessary to use SSL, to prevent errors accessing a confirm route via ajax (eg simple module), on sites that use https.

Also, it is necessary to create 1.5 branch for commit `386dea5` and apply the same patch for it.